### PR TITLE
Limit http POST to batch size of 50 since otherwise request fails on …

### DIFF
--- a/aware-core/src/main/java/com/aware/syncadapters/AwareSyncAdapter.java
+++ b/aware-core/src/main/java/com/aware/syncadapters/AwareSyncAdapter.java
@@ -272,11 +272,14 @@ public class AwareSyncAdapter extends AbstractThreadedSyncAdapter {
             return 0;
         }
 
-        double availableRam = memInfo.totalMem / 1048576000.0;
-        if (availableRam <= 1.0) return 500;
-        if (availableRam <= 2.0) return 1500;
-        if (availableRam <= 4.0) return 5000;
-        return 10000;
+//        double availableRam = memInfo.totalMem / 1048576000.0;
+//        if (availableRam <= 1.0) return 500;
+//        if (availableRam <= 2.0) return 1500;
+//        if (availableRam <= 4.0) return 5000;
+//        return 10000;
+	// limit http POST to batch size of 50 since otherwise 
+	// request fails on the server side over HTTP POST maximum capacity exceed exception 
+        return 50;
     }
 
 


### PR DESCRIPTION
Limit http POST to batch size of 50 since otherwise request fails on the server side over HTTP POST maximum capacity exceed exception 

Attached are server side and client side exceptions due to this issue. As a result some of the tables are not updated at all (for example keyboard, gsm_neighbor, applications_notification).

There is no way to extend the POST body side effectively on the server side since it's probably hard coded in the HTTP library (even though there is an interface to change it, practicaly it doesn't work).

<img width="1310" alt="Screenshot 2024-07-05 at 6 50 40" src="https://github.com/denzilferreira/aware-client/assets/2284463/ad703ab0-bee8-40b6-bbda-96b19833d351">
<img width="1512" alt="Screenshot 2024-07-05 at 9 22 19" src="https://github.com/denzilferreira/aware-client/assets/2284463/037ee1c8-cd44-4472-8ebd-159f6ced01cb">
